### PR TITLE
Breakpoint set to 375 and logo asize adjusted for mobile view.

### DIFF
--- a/src/components/Layouts/Footer/Footer.module.css
+++ b/src/components/Layouts/Footer/Footer.module.css
@@ -32,7 +32,7 @@
 }
 
 .logo {
-  color: var(--gray-white, #FFF);
+  color: var(--character-primary-inverse);
   /* Headers/H1 */
   font-family: Montserrat;
   font-size: 38px;
@@ -50,7 +50,7 @@
 
 .linksWrapper a,
 .linksWrapper p{
-  color: var(--gray-white, #FFF);
+  color: var(--character-primary-inverse);
   text-align: center;
   /* Text Body/semibold */
   font-family: "Work Sans";
@@ -82,10 +82,10 @@
 }
 
 .divider {
-  width: 100%;
   max-width: 1168px;
+  width: 100%;
   height: 1px;
-  background: var(--purple-purple-1, #F6EDFC);
+  background:  var(--primary1);
 }
 
 .secondaryLinksWrapper {
@@ -120,29 +120,60 @@
   text-decoration: none;
 }
 
-@media screen and (max-width: 900px ){
+@media screen and (max-width: 375px ){
   .footerWrapper {
+    display: flex;
     height: fit-content;
-    padding: 34px 16px;
+    width: 375px;
+    padding: var(--spacing-spacing-09, 48px) var(--spacing-spacing-05, 16px);
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: var(--spacing-spacing-07, 32px);
   }
 
+  .divider {
+    display: none;
+  }
   .unauthPagesWrapper {
     gap: 32px;
   }
 
   .linksWrapper {
     flex-direction: column;
+    gap: var(--spacing-spacing-07, 32px);
   }
 
+  .logo {
+    font-size: 24px;
+  }
+
+  .logoWrapper {
+    width: 343px;
+    height: 27px;
+  }
 
   .secondaryLinksWrapper {
+    display: flex;
     flex-direction: column;
+    justify-content: flex-start;
     align-items: flex-start;
-    gap: 24px;
+    gap: var(--spacing-spacing-03, 8px);
   }
   .secondaryLinks {
     display: flex;
     align-items: flex-start;
-    gap: 28px;
+    gap: var(--spacing-spacing-07, 32px);
+  }
+  .secondaryLinks a,
+  .secondaryLinks p {
+    color: var(--character-primary-inverse);
+    text-align: center;
+    font-family: "Work Sans";
+    font-size: 10px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 32px; /* 228.571% */
+    text-decoration-line: underline;
   }
 }


### PR DESCRIPTION
- Switched to new variable colors
- set mobile view breakpoint to 375px
- adjusted logo size to fit mobile view
- added CSS class desc. to the mobile view to better fit the Figma design. (Adjusted spacing, padding, text size etc.)